### PR TITLE
fix: copying layers on Windows OS (2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "main": "./dist/index.mjs",
@@ -33,6 +33,7 @@
     "build": "unbuild",
     "dev": "unbuild --stub",
     "lint": "eslint .",
+    "lint:fix": "nr lint --fix",
     "prepublishOnly": "nr build",
     "release": "bumpp && npm publish",
     "test": "vitest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export default function layeredFilesPlugin(options: PluginOptions = {}): AstroIn
     name: 'astro-layered-files',
     hooks: {
       'astro:config:setup': async ({ command, config, updateConfig }) => {
-        // we don't want to copy and watch layers when running the preview command
+        // we don't want to copy layers when running the preview command
         if (command === 'preview') {
           return
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,135 +1,156 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import { gitget } from 'gitget';
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import url from 'node:url'
+import { gitget } from 'gitget'
+import type { AstroIntegration } from 'astro'
 
-function getDirectoryPaths(rootDir: string | URL) {
-  const rootPath = rootDir instanceof URL ? rootDir.pathname : rootDir;
+interface ExternalLayer {
+  [key: string]: string // '3.new-theme': 'git:user/repo' or 'npm:package'
+}
+
+interface PluginOptions {
+  external?: ExternalLayer
+}
+
+export default function layeredFilesPlugin(options: PluginOptions = {}): AstroIntegration {
   return {
-    layers: path.join(rootPath, 'layers'),
-    output: path.join(rootPath, '.layers')
-  };
+    name: 'astro-layered-files',
+    hooks: {
+      'astro:config:setup': async ({ command, config, updateConfig }) => {
+        // we don't want to copy and watch layers when running the preview command
+        if (command === 'preview') {
+          return
+        }
+
+        const rootDir = config.root || process.cwd()
+        const rootDirPath = rootDir instanceof URL ? url.fileURLToPath(rootDir) : rootDir
+        const srcDir = new URL(`file://${path.resolve(rootDirPath, './.layers')}/`)
+
+        if (srcDir.pathname === config.srcDir.pathname) {
+          if (command === 'dev') {
+            createFileWatcher(rootDirPath)
+          }
+          return
+        }
+
+        config.srcDir = srcDir
+
+        await mergeLayeredFiles(rootDir, options)
+
+        updateConfig(config)
+      },
+    },
+  }
+}
+
+interface DirectoryPaths {
+  layers: string
+  output: string
+}
+
+function getDirectoryPaths(rootDir: string | URL): DirectoryPaths {
+  const rootPath = rootDir instanceof URL ? url.fileURLToPath(rootDir) : rootDir
+  return {
+    layers: path.resolve(rootPath, 'layers'),
+    output: path.resolve(rootPath, '.layers'),
+  }
 }
 
 function ensureDirectoryExists(dirPath: string): void {
   if (!fs.existsSync(dirPath)) {
-    fs.mkdirSync(dirPath, { recursive: true });
+    fs.mkdirSync(dirPath, { recursive: true })
   }
 }
 
 function getOrderedLayers(layersPath: string, externalPath: string): string[] {
-  const localLayers = fs.existsSync(layersPath) 
+  const localLayers = fs.existsSync(layersPath)
     ? fs.readdirSync(layersPath)
-        .filter(file => fs.statSync(path.join(layersPath, file)).isDirectory())
-    : [];
-    
+      .filter(file => fs.statSync(path.resolve(layersPath, file)).isDirectory())
+    : []
+
   const externalLayers = fs.existsSync(externalPath)
     ? fs.readdirSync(externalPath)
-        .filter(file => fs.statSync(path.join(externalPath, file)).isDirectory())
-    : [];
+      .filter(file => fs.statSync(path.resolve(externalPath, file)).isDirectory())
+    : []
 
-  return [...localLayers, ...externalLayers].sort((a, b) => b.localeCompare(a));
+  return [...localLayers, ...externalLayers].sort((a, b) => b.localeCompare(a))
 }
 
 function copyRecursive(sourcePath: string, destPath: string): void {
-  const isDirectory = fs.statSync(sourcePath).isDirectory();
-  if (!isDirectory) return;
+  const isDirectory = fs.statSync(sourcePath).isDirectory()
+  if (!isDirectory)
+    return
 
-  const files = fs.readdirSync(sourcePath);
-  
+  const files = fs.readdirSync(sourcePath)
+
   for (const file of files) {
-    const srcPath = path.join(sourcePath, file);
-    const dstPath = path.join(destPath, file);
-    
+    const srcPath = path.resolve(sourcePath, file)
+    const dstPath = path.resolve(destPath, file)
+
     if (fs.statSync(srcPath).isDirectory()) {
-      ensureDirectoryExists(dstPath);
-      copyRecursive(srcPath, dstPath);
-    } else {
-      fs.copyFileSync(srcPath, dstPath);
+      ensureDirectoryExists(dstPath)
+      copyRecursive(srcPath, dstPath)
+    }
+    else {
+      fs.copyFileSync(srcPath, dstPath)
     }
   }
 }
 
 async function downloadExternalLayers(
-  outputPath: string, 
-  externalLayers: ExternalLayer
+  outputPath: string,
+  externalLayers: ExternalLayer,
 ): Promise<void> {
   for (const [layerName, source] of Object.entries(externalLayers)) {
-    const layerPath = path.join(outputPath, '.external', layerName);
-    ensureDirectoryExists(layerPath);
-    console.log(layerPath);
+    const layerPath = path.resolve(outputPath, '.external', layerName)
+    ensureDirectoryExists(layerPath)
+    console.log(layerPath)
     await gitget({
       silent: true,
       folder: `./${layerPath}`,
-      ...(source.startsWith('npm:') 
-        ? { npm: source.replace('npm:', ''), 
-      }
-        : { 
+      ...(source.startsWith('npm:')
+        ? { npm: source.replace('npm:', ''),
+          }
+        : {
             user: source.replace('git:', '').split('/')[0],
             repo: source.replace('git:', '').split('/')[1],
-          })
-    });
+          }),
+    })
   }
 }
 
 async function mergeLayeredFiles(
-  rootDir: string | URL, 
-  options: PluginOptions = {}
+  rootDir: string | URL,
+  options: PluginOptions = {},
 ): Promise<string> {
-  const paths = getDirectoryPaths(rootDir);
-  ensureDirectoryExists(paths.output);
-  
+  const paths = getDirectoryPaths(rootDir)
+  ensureDirectoryExists(paths.output)
+
   if (options.external) {
-    const externalPath = path.join(paths.output, '.external');
-    ensureDirectoryExists(externalPath);
-    const rootPath = rootDir instanceof URL ? rootDir.pathname : rootDir;
-    await downloadExternalLayers(paths.output.replace(rootPath, ''), options.external);
+    const externalPath = path.resolve(paths.output, '.external')
+    ensureDirectoryExists(externalPath)
+    const rootPath = rootDir instanceof URL ? url.fileURLToPath(rootDir) : rootDir
+    await downloadExternalLayers(paths.output.replace(rootPath, ''), options.external)
   }
-  
-  const externalPath = path.join(paths.output, '.external');
-  const layers = getOrderedLayers(paths.layers, externalPath);
-  
+
+  const externalPath = path.resolve(paths.output, '.external')
+  const layers = getOrderedLayers(paths.layers, externalPath)
+
   for (const layer of layers) {
-    const layerPath = fs.existsSync(path.join(paths.layers, layer))
-      ? path.join(paths.layers, layer)
-      : path.join(externalPath, layer);
-    
-    copyRecursive(layerPath, paths.output);
+    const layerPath = fs.existsSync(path.resolve(paths.layers, layer))
+      ? path.resolve(paths.layers, layer)
+      : path.resolve(externalPath, layer)
+
+    copyRecursive(layerPath, paths.output)
   }
-  
-  return paths.output;
+
+  return paths.output
 }
 
 function createFileWatcher(rootDir: string | URL): void {
-  const paths = getDirectoryPaths(rootDir);
+  const paths = getDirectoryPaths(rootDir)
   fs.watch(paths.layers, { recursive: true }, () => {
-    mergeLayeredFiles(rootDir);
-  });
-}
-
-interface ExternalLayer {
-  [key: string]: string; // '3.new-theme': 'git:user/repo' or 'npm:package'
-}
-
-interface PluginOptions {
-  external?: ExternalLayer;
-}
-
-export default function layeredFilesPlugin(options: PluginOptions = {}) {
-  return {
-    name: 'astro-layered-files',
-    hooks: {
-      'astro:config:setup': async ({ command, config }) => {
-        const rootDir = config.root || process.cwd();
-        await mergeLayeredFiles(rootDir, options);
-        
-        config.srcDir = new URL('.layers/', 
-          rootDir instanceof URL ? rootDir : new URL(`file://${rootDir}`)
-        );
-        
-        if (command === 'dev') {
-          createFileWatcher(rootDir);
-        }
-      }
-    }
-  };
+    mergeLayeredFiles(rootDir)
+  })
 }


### PR DESCRIPTION
This PR also includes a protection to avoid copying layers when running `preview` command.

@filrak did you run eslint in your local? `@antfu/eslint-config` not using semi

gh layer not tested on my local

supersedes #1